### PR TITLE
rulenum is not mutually exclusive of other args

### DIFF
--- a/lib/iptables/insert.js
+++ b/lib/iptables/insert.js
@@ -42,10 +42,9 @@ module.exports = function (options, cb) {
   if (typeof options.rulenum != 'undefined') {
     args = args.concat(options.rulenum);
   }
-  else {
-    var common_rule_specs = processCommonRuleSpecs(options);
-    args = args.concat(common_rule_specs);
-  }
+
+  var common_rule_specs = processCommonRuleSpecs(options);
+  args = args.concat(common_rule_specs);
 
   /*
    * Execute command.

--- a/lib/iptables/replace.js
+++ b/lib/iptables/replace.js
@@ -42,10 +42,9 @@ module.exports = function (options, cb) {
   if (typeof options.rulenum != 'undefined') {
     args = args.concat(options.rulenum);
   }
-  else {
-    var common_rule_specs = processCommonRuleSpecs(options);
-    args = args.concat(common_rule_specs);
-  }
+
+  var common_rule_specs = processCommonRuleSpecs(options);
+  args = args.concat(common_rule_specs);
 
   /*
    * Execute command.


### PR DESCRIPTION
When trying to insert into a specific position specified by "rulenum" the rule-specification arguments where not being added.  Both "rulenum" and rule args should be added to the command.